### PR TITLE
buildディレクトリがなければ作る

### DIFF
--- a/generate_html.js
+++ b/generate_html.js
@@ -157,6 +157,9 @@ if (config.imprint) {
 }
 
 finalHtml += '</body></html>';
+if (!fs.existsSync('./build')){
+    fs.mkdirSync('./build', { recursive: true });
+}
 fs.writeFileSync('./build/output.html', finalHtml);
 
 /**


### PR DESCRIPTION
## 目的

`git clone`した時点では`build`ディレクトリがないので、`'./build/output.html'`の出力に失敗します。そのため、ファイルを出力する直前で `build`ディレクトリを作成します。

## 結果

- リポジトリをクローンした人が `build` ディレクトリを作成するという手順が必要なくなる。