### PR TITLE
Dockerでの実行手順を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,3 @@ ADD template/*.ttf /usr/share/fonts/
 RUN fc-cache -fv
 
 WORKDIR /app
-
-RUN npm install

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Markdownで章ごとに執筆し、config.ymlを書き換えるだけで、同�
 
 ```
 docker compose build
+docker compose run flightbooks npm install
 docker compose run flightbooks node generate_html.js
 docker compose run flightbooks node generate_pdf.js
 ```


### PR DESCRIPTION
## 目的

カレントディレクトリのボリュームマウントは `Dockerfile`ではなく`docker-compose.yml` に記載しているので、イメージのビルド時点では`package.json`がなく、`RUN npm install`は失敗します。
そこで、`Dockerfile`から`RUN npm install`を削除し、代わりに実行手順に `docker compose run flightbooks npm install`を挿入します。

## 結果

`README.md`通りに実行したときにPDF作成に成功する。
